### PR TITLE
Add basic weather forecast integration test

### DIFF
--- a/DevHabit.Api.Tests/DevHabit.Api.Tests.csproj
+++ b/DevHabit.Api.Tests/DevHabit.Api.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-preview.4.24267.6" />
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../DevHabit.Api/DevHabit.Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/DevHabit.Api.Tests/WeatherTests/WeatherForecastTests.cs
+++ b/DevHabit.Api.Tests/WeatherTests/WeatherForecastTests.cs
@@ -1,0 +1,23 @@
+using System.Net.Http.Json;
+using DevHabit.Api;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace DevHabit.Api.Tests.WeatherTests;
+
+public class WeatherForecastTests
+{
+    [Fact]
+    public async Task GetWeatherForecast_ReturnsFiveItems()
+    {
+        await using var factory = new WebApplicationFactory<Program>();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/weatherforecast");
+
+        response.EnsureSuccessStatusCode();
+        var forecasts = await response.Content.ReadFromJsonAsync<WeatherForecast[]>();
+        Assert.NotNull(forecasts);
+        Assert.Equal(5, forecasts!.Length);
+    }
+}

--- a/DevHabit.sln
+++ b/DevHabit.sln
@@ -5,7 +5,11 @@ VisualStudioVersion = 17.13.35931.197
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{b383da6e-6e5a-4e5f-a16b-aae480f4a745}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DevHabit.Api", "DevHabit.Api\DevHabit.Api.csproj", "{0C62C003-22F6-49C1-A085-8B7E72A9A144}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DevHabit.Api.Tests", "DevHabit.Api.Tests\DevHabit.Api.Tests.csproj", "{64fff73e-20c1-4a9a-9032-b8806f6b5438}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
 	ProjectSection(SolutionItems) = preProject
@@ -29,14 +33,19 @@ Global
 		{81DDED9D-158B-E303-5F62-77A2896D2A5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{81DDED9D-158B-E303-5F62-77A2896D2A5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{81DDED9D-158B-E303-5F62-77A2896D2A5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{81DDED9D-158B-E303-5F62-77A2896D2A5A}.Release|Any CPU.Build.0 = Release|Any CPU
+                {81DDED9D-158B-E303-5F62-77A2896D2A5A}.Release|Any CPU.Build.0 = Release|Any CPU
+                {64fff73e-20c1-4a9a-9032-b8806f6b5438}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {64fff73e-20c1-4a9a-9032-b8806f6b5438}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {64fff73e-20c1-4a9a-9032-b8806f6b5438}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {64fff73e-20c1-4a9a-9032-b8806f6b5438}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{0C62C003-22F6-49C1-A085-8B7E72A9A144} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
-	EndGlobalSection
+        GlobalSection(NestedProjects) = preSolution
+                {0C62C003-22F6-49C1-A085-8B7E72A9A144} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+                {64fff73e-20c1-4a9a-9032-b8806f6b5438} = {b383da6e-6e5a-4e5f-a16b-aae480f4a745}
+        EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B5B82C78-8781-4C22-8A37-1E6A767DBBC0}
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add xUnit test project `DevHabit.Api.Tests`
- call `/weatherforecast` using `WebApplicationFactory`
- assert we get 200 OK and five forecasts
- include new test project in solution

## Testing
- `dotnet test DevHabit.sln` *(fails: NETSDK1045 – current .NET SDK does not support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_685b0ba56a4c832f904b7d69b4cbda01