### PR TITLE
Fix DB context visibility and centralize test package versions

### DIFF
--- a/DevHabit.Api/Database/ApplicationDBContext.cs
+++ b/DevHabit.Api/Database/ApplicationDBContext.cs
@@ -2,7 +2,7 @@
 
 namespace DevHabit.Api.Database
 {
-    internal sealed class ApplicationDBContext(DbContextOptions<ApplicationDBContext> options) : DbContext(options)
+    public sealed class ApplicationDBContext(DbContextOptions<ApplicationDBContext> options) : DbContext(options)
     {
 
         public DbSet<Entities.Habit> Habits { get; set; }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,19 +1,23 @@
-﻿<Project>
-	<PropertyGroup>
-		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
-		<PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
-		<PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5" />
-		<PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
-		<PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.5" />
-		<PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-		<PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
-		<PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
-		<PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
-		<PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
-		<PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
-		<PackageVersion Include="SonarAnalyzer.CSharp" Version="10.9.0.115408" />
-	</ItemGroup>
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.9.0.115408" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- make `ApplicationDBContext` public so controllers can depend on it
- clean up `Directory.Packages.props` and add test package versions for CPM

## Testing
- `dotnet build DevHabit.sln` *(fails: current .NET SDK does not support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_685b1179e5c0832f981616149ececc57